### PR TITLE
Implement dataset preparation script and simplify dataset loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,104 @@
 # IB-sampling
-A GitHub repo holding the source code of our proposed custom dataloader. This work was submitted to the DEMI workshop of MICAI 2025  Source code will be made publically available upon paper acceptance, stay tuned
+
+A modular dataloader for patch-based whole-body lesion detection. The package is
+split into small components so the dataset, sampler and loader can be reused in
+other projects or adapted to different modalities.
+
+## Package structure
+
+``ib_sampling`` exposes a few key utilities:
+
+- `MedicalPatchDataset` – loads pre-extracted 3D patches and keeps a cache of
+  frequently used patches in memory.
+- `BalancedBatchSampler` – draws a balanced mix of positive and negative
+  patches for each epoch.
+- `get_loader` – convenience helper that builds training and validation
+  dataloaders.
+- `train_validate_dicts` – splits patient IDs into train/validation folds with
+  a configurable number of splits via ``max_splits``.
+
+The repository also provides a template ``prepare_dataset.py`` script that
+converts raw volumes into patch datasets compatible with the dataloader.
+
+## Raw data layout
+
+Before running the preparation script, the raw data should be organised with one
+directory per acquisition:
+
+```
+raw_dataset/
+├── Patient01_a/
+│   ├── T1.nii.gz
+│   ├── b1000.nii.gz
+│   └── GT.nii.gz
+├── Patient01_b/
+│   └── ...
+└── Patient02_a/
+    └── ...
+```
+
+Each folder contains one NIfTI volume per modality (any names are accepted) and
+a ground-truth mask named ``GT.nii.gz``.
+
+## Preparing patches
+
+Use the provided script to extract positive and negative patches:
+
+```
+python prepare_dataset.py RAW_DIR OUTPUT_DIR --patch-size 128 128 128 \
+       --modalities T1 b1000
+```
+
+The script performs 1–99 percentile normalisation on every modality, crops
+positive patches around each connected component with a 10‑voxel margin and a
+minimum size of ``128³``, and extracts background patches with a sliding window
+of the same size and 50 % overlap. Patches are written to
+``OUTPUT_DIR/lesion_patches`` and ``OUTPUT_DIR/background_patches`` using the
+following convention:
+
+- ``<pid>_<mod>_positive_<idx>.nii.gz`` and
+  ``<pid>_label_positive_<idx>.nii.gz``
+- ``<pid>_<mod>_negative_<idx>.nii.gz`` and
+  ``<pid>_label_negative_<idx>.nii.gz``
+
+## Using the dataloader
+
+```python
+from argparse import Namespace
+from ib_sampling.loader import get_loader
+
+args = Namespace(
+    data_dir="OUTPUT_DIR",
+    roi_x=128, roi_y=128, roi_z=128,
+    batch_size=4,
+    ratio=1.0,                 # negative:positive ratio
+    split=1, max_splits=5,
+    seed=0, rank=0, world_size=1,
+    num_workers=4, distributed=False,
+    modalities=["T1", "b1000"],
+)
+
+train_loader, val_loader = get_loader(args)
+```
+
+Each item returned by the loaders is a dictionary with ``image`` and ``label``
+keys containing tensors shaped ``(C, Z, Y, X)`` and ``(1, Z, Y, X)``
+respectively.
+
+## Dataloader mechanics
+
+- When instantiated, ``MedicalPatchDataset`` discovers the available modalities
+  and preloads all positive patches into memory. In a distributed setup the
+  positives are evenly split across workers.
+- For every epoch, ``BalancedBatchSampler`` randomly selects the required number
+  of negative patches to satisfy the desired ratio. The dataset then preloads
+  only those negatives into a cache before iteration begins.
+- The sampler reports the number of positives and negatives each epoch and
+  yields a balanced list of indices. The dataloader fetches the cached samples
+  and applies the requested transforms.
+- During validation all patches are cached up-front, removing disk I/O during
+  evaluation.
+
+This design keeps GPU utilisation high by avoiding repeated disk reads while
+still supporting large background pools.
+

--- a/ib_sampling/__init__.py
+++ b/ib_sampling/__init__.py
@@ -1,0 +1,13 @@
+"""IB-sampling data loading package."""
+
+from .dataset import MedicalPatchDataset
+from .loader import get_loader
+from .sampler import BalancedBatchSampler
+from .utils import train_validate_dicts
+
+__all__ = [
+    "MedicalPatchDataset",
+    "BalancedBatchSampler",
+    "get_loader",
+    "train_validate_dicts",
+]

--- a/ib_sampling/dataset.py
+++ b/ib_sampling/dataset.py
@@ -1,0 +1,238 @@
+"""Dataset utilities for IB-sampling."""
+
+from __future__ import annotations
+
+import glob
+import os
+import random
+import time
+from typing import Dict, List, Optional
+
+import nibabel as nib
+import numpy as np
+from torch.utils.data import Dataset
+from monai.transforms import RandSpatialCropd, SpatialPadd
+
+
+class MedicalPatchDataset(Dataset):
+    """Dataset of pre-extracted 3D patches for medical images."""
+
+    def __init__(
+        self,
+        root_dir: str,
+        patch_size: tuple[int, int, int],
+        transform: Optional[callable] = None,
+        rank: int = 0,
+        world_size: int = 1,
+        patient_ids: Optional[List[str]] = None,
+        is_training: bool = True,
+        modalities: Optional[List[str]] = None,
+    ) -> None:
+        self.root_dir = root_dir
+        self.patch_size = patch_size
+        self.transform = transform
+        self.rank = rank
+        self.world_size = world_size
+        self.is_training = is_training
+
+        # Initialize shuffle and epoch attributes
+        self.shuffle = True
+        self.epoch = 0
+
+        self.samples: List[Dict] = []
+        self.modalities = modalities or self._discover_modalities(root_dir)
+
+        lesion_patch_dir = os.path.join(root_dir, "lesion_patches")
+        background_patch_dir = os.path.join(root_dir, "background_patches")
+        self._load_samples(lesion_patch_dir, "positive", patient_ids)
+
+        if self.is_training:
+            self._load_samples(background_patch_dir, "negative", patient_ids)
+
+        self.positive_indices = [i for i, s in enumerate(self.samples) if s["type"] == "positive"]
+        self.negative_indices = [i for i, s in enumerate(self.samples) if s["type"] == "negative"]
+
+        if self.is_training:
+            self.split_positive_indices()
+            self.positive_cache: Dict[int, Dict] = {}
+            self.negative_cache: Dict[int, Dict] = {}
+            self._preload_positive_samples()
+        else:
+            self.cache: Dict[int, Dict] = {}
+            self._preload_all_samples()
+
+    def split_positive_indices(self) -> None:
+        total_positives = len(self.positive_indices)
+        indices_per_gpu = total_positives // self.world_size
+
+        indices = self.positive_indices.copy()
+        if self.shuffle:
+            random.seed(self.rank)
+            random.shuffle(indices)
+
+        indices = indices[: indices_per_gpu * self.world_size]
+        start = self.rank * indices_per_gpu
+        end = start + indices_per_gpu
+        self.positive_indices = indices[start:end]
+        self.num_positives = len(self.positive_indices)
+
+    def _preload_positive_samples(self) -> None:
+        print(f"GPU {self.rank}: Preloading positive samples into cache...")
+        start_time = time.time()
+        for idx in self.positive_indices:
+            sample = self._load_sample(idx, apply_random_crop=False)
+            self.positive_cache[idx] = sample
+        end_time = time.time()
+        print(
+            f"GPU {self.rank}: Preloaded {len(self.positive_cache)} positive samples in {end_time - start_time:.2f} seconds."
+        )
+
+    def _preload_negative_samples(self, negative_indices: List[int]) -> None:
+        print(f"GPU {self.rank}: Preloading negative samples into cache...")
+        start_time = time.time()
+        self.negative_cache.clear()
+        for idx in negative_indices:
+            sample = self._load_sample(idx, apply_random_crop=False)
+            self.negative_cache[idx] = sample
+        end_time = time.time()
+        print(
+            f"GPU {self.rank}: Preloaded {len(self.negative_cache)} negative samples in {end_time - start_time:.2f} seconds."
+        )
+
+    def _preload_all_samples(self) -> None:
+        print(f"GPU {self.rank}: Preloading all validation samples into cache...")
+        start_time = time.time()
+        for idx in range(len(self.samples)):
+            sample = self._load_sample(idx, apply_random_crop=False)
+            self.cache[idx] = sample
+        end_time = time.time()
+        print(
+            f"GPU {self.rank}: Preloaded {len(self.cache)} validation samples in {end_time - start_time:.2f} seconds."
+        )
+
+    def _discover_modalities(self, root_dir: str) -> List[str]:
+        """Infer modality names from patch filenames."""
+        modalities = set()
+        for patch_dir in ["lesion_patches", "background_patches"]:
+            path = os.path.join(root_dir, patch_dir)
+            for fname in glob.glob(os.path.join(path, "*.nii*")):
+                base = os.path.basename(fname)
+                if "label" in base:
+                    continue
+                parts = base.replace(".nii.gz", "").replace(".nii", "").split("_")
+                if len(parts) >= 3:
+                    modalities.add(parts[-3])
+        return sorted(modalities)
+
+    def _load_sample(self, idx: int, apply_random_crop: bool = False) -> Dict[str, np.ndarray]:
+        sample_info = self.samples[idx]
+        modalities = sample_info["modalities"]
+        label_path = sample_info["label_path"]
+
+        modality_images = []
+        for modality in self.modalities:
+            image_path = modalities[modality]
+            image = nib.load(image_path).get_fdata(dtype=np.float32)
+            modality_images.append(image)
+
+        image = np.stack(modality_images, axis=0)
+        label = nib.load(label_path).get_fdata(dtype=np.float32)
+        label = np.expand_dims(label, axis=0)
+
+        sample = {"image": image, "label": label}
+
+        pad_transform = SpatialPadd(keys=["image", "label"], spatial_size=self.patch_size, method="end")
+        sample = pad_transform(sample)
+
+        return sample
+
+    def __len__(self) -> int:
+        if self.is_training:
+            return len(self.positive_cache) + len(self.negative_cache)
+        return len(self.samples)
+
+    def __getitem__(self, idx: int):
+        if self.is_training:
+            if idx in self.positive_cache:
+                sample = self.positive_cache[idx]
+                sample_type = "positive"
+            elif idx in self.negative_cache:
+                sample = self.negative_cache[idx]
+                sample_type = "negative"
+            else:
+                sample = self._load_sample(idx, apply_random_crop=False)
+                sample_type = self.samples[idx]["type"]
+                if sample_type == "positive":
+                    self.positive_cache[idx] = sample
+                elif sample_type == "negative":
+                    self.negative_cache[idx] = sample
+                else:
+                    raise ValueError(f"Unknown sample type {sample_type} for index {idx}")
+            sample = self._apply_transforms(sample, sample_type=sample_type)
+            return sample
+
+        if idx in self.cache:
+            sample = self.cache[idx]
+        else:
+            sample = self._load_sample(idx, apply_random_crop=False)
+            self.cache[idx] = sample
+        if self.transform:
+            sample = self.transform(sample)
+        return sample
+
+    def _apply_transforms(self, sample: Dict[str, np.ndarray], sample_type: str):
+        if sample_type == "positive":
+            crop = RandSpatialCropd(keys=["image", "label"], roi_size=self.patch_size, random_size=False)
+            sample = crop(sample)
+
+        if self.transform:
+            sample = self.transform(sample)
+        return sample
+
+    def _load_samples(self, patch_dir: str, sample_type: str, patient_ids: Optional[List[str]] = None) -> None:
+        image_files = glob.glob(os.path.join(patch_dir, "*.nii*"))
+        sample_dict: Dict[str, Dict] = {}
+        for image_path in image_files:
+            filename = os.path.basename(image_path)
+            if "label" in filename:
+                continue
+            filename_no_ext = filename.replace(".nii.gz", "").replace(".nii", "")
+            parts = filename_no_ext.split("_")
+            if len(parts) < 4:
+                continue
+            patch_id = parts[-1]
+            patch_type = parts[-2]
+            modality = parts[-3]
+            pid = "_".join(parts[:-3])
+
+            if patient_ids is not None and pid not in patient_ids:
+                continue
+
+            patch_key = f"{pid}_{patch_type}_{patch_id}"
+            if patch_key not in sample_dict:
+                sample_dict[patch_key] = {
+                    "patient_id": pid,
+                    "patch_type": patch_type,
+                    "patch_id": patch_id,
+                    "modalities": {},
+                    "label_path": "",
+                    "type": sample_type,
+                }
+            sample_dict[patch_key]["modalities"][modality] = image_path
+
+        for patch_key, sample_info in sample_dict.items():
+            label_filename = (
+                f"{sample_info['patient_id']}_label_{sample_info['patch_type']}_{sample_info['patch_id']}.nii.gz"
+            )
+            label_path = os.path.join(patch_dir, label_filename)
+            if not os.path.exists(label_path):
+                label_filename = label_filename.replace(".nii.gz", ".nii")
+                label_path = os.path.join(patch_dir, label_filename)
+                if not os.path.exists(label_path):
+                    continue
+            sample_info["label_path"] = label_path
+            if set(self.modalities).issubset(sample_info["modalities"].keys()):
+                self.samples.append(sample_info)
+
+    def set_epoch(self, epoch: int) -> None:
+        self.epoch = epoch

--- a/ib_sampling/loader.py
+++ b/ib_sampling/loader.py
@@ -1,0 +1,117 @@
+"""Dataloader construction utilities."""
+
+from __future__ import annotations
+
+import random
+import numpy as np
+import torch
+from torch.utils.data import DataLoader
+from monai.data import list_data_collate
+from monai.transforms import (
+    Compose,
+    RandFlipd,
+    RandRotate90d,
+    RandScaleIntensityd,
+    RandShiftIntensityd,
+    RandSpatialCropd,
+    ToTensord,
+)
+
+from .dataset import MedicalPatchDataset
+from .sampler import BalancedBatchSampler
+from .utils import train_validate_dicts
+
+
+def get_loader(args):
+    """Create training and validation data loaders."""
+    root_dir = args.data_dir
+    patch_size = (args.roi_x, args.roi_y, args.roi_z)
+    batch_size = args.batch_size
+    ratio = args.ratio
+    modalities = getattr(args, "modalities", None)
+    if isinstance(modalities, str):
+        modalities = [m.strip() for m in modalities.split(",") if m.strip()]
+
+    random.seed(args.seed + args.rank)
+    torch.manual_seed(args.seed + args.rank)
+    np.random.seed(args.seed + args.rank)
+
+    train_transforms = Compose(
+        [
+            RandFlipd(keys=["image", "label"], prob=0.5, spatial_axis=0),
+            RandFlipd(keys=["image", "label"], prob=0.5, spatial_axis=1),
+            RandFlipd(keys=["image", "label"], prob=0.5, spatial_axis=2),
+            RandRotate90d(keys=["image", "label"], prob=0.2, max_k=3),
+            RandScaleIntensityd(keys="image", factors=0.1, prob=0.1),
+            RandShiftIntensityd(keys="image", offsets=0.1, prob=0.1),
+            ToTensord(keys=["image", "label"]),
+        ]
+    )
+
+    val_transforms = Compose(
+        [
+            RandSpatialCropd(keys=["image", "label"], roi_size=patch_size, random_size=False),
+            ToTensord(keys=["image", "label"]),
+        ]
+    )
+
+    train_patient_ids, val_patient_ids = train_validate_dicts(root_dir, args)
+
+    train_dataset = MedicalPatchDataset(
+        root_dir,
+        patch_size,
+        transform=train_transforms,
+        rank=args.rank,
+        world_size=args.world_size,
+        patient_ids=train_patient_ids,
+        is_training=True,
+        modalities=modalities,
+    )
+
+    if getattr(args, "distributed", False):
+        train_sampler = BalancedBatchSampler(
+            train_dataset,
+            ratio=ratio,
+            num_replicas=args.world_size,
+            rank=args.rank,
+            shuffle=True,
+        )
+    else:
+        train_sampler = BalancedBatchSampler(
+            train_dataset,
+            ratio=ratio,
+            num_replicas=1,
+            rank=0,
+            shuffle=True,
+        )
+
+    train_loader = DataLoader(
+        train_dataset,
+        batch_size=batch_size,
+        sampler=train_sampler,
+        num_workers=args.num_workers,
+        pin_memory=True,
+        collate_fn=list_data_collate,
+    )
+
+    val_dataset = MedicalPatchDataset(
+        root_dir,
+        patch_size,
+        transform=val_transforms,
+        rank=args.rank,
+        world_size=args.world_size,
+        patient_ids=val_patient_ids,
+        is_training=False,
+        modalities=modalities,
+    )
+
+    val_loader = DataLoader(
+        val_dataset,
+        batch_size=batch_size,
+        shuffle=False,
+        num_workers=0,
+        pin_memory=True,
+        collate_fn=list_data_collate,
+    )
+
+    return train_loader, val_loader

--- a/ib_sampling/sampler.py
+++ b/ib_sampling/sampler.py
@@ -1,0 +1,82 @@
+"""Custom samplers used in IB-sampling."""
+
+from __future__ import annotations
+
+from typing import Iterator, List, Optional
+
+import torch
+from torch.utils.data import Sampler
+
+
+class BalancedBatchSampler(Sampler[int]):
+    """Sampler that yields a balanced mix of positive and negative patches."""
+
+    def __init__(
+        self,
+        dataset,
+        ratio: float = 1,
+        num_replicas: Optional[int] = None,
+        rank: Optional[int] = None,
+        shuffle: bool = True,
+    ) -> None:
+        self.dataset = dataset
+        self.ratio = ratio
+        self.shuffle = shuffle
+        self.epoch = 0
+
+        if num_replicas is None:
+            self.num_replicas = (
+                torch.distributed.get_world_size() if torch.distributed.is_initialized() else 1
+            )
+        else:
+            self.num_replicas = num_replicas
+
+        if rank is None:
+            self.rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+        else:
+            self.rank = rank
+
+        self.positive_indices = self.dataset.positive_indices
+        self.num_positives = len(self.positive_indices)
+        self.num_negatives_per_epoch = int(self.num_positives * self.ratio)
+
+    def __iter__(self) -> Iterator[int]:
+        g = torch.Generator()
+        g.manual_seed(self.epoch + self.rank)
+        self.positive_indices = self.dataset.positive_indices
+        self.num_positives = len(self.positive_indices)
+        self.num_negatives_per_epoch = int(self.num_positives * self.ratio)
+
+        negative_indices_all = self.dataset.negative_indices
+        num_negatives = self.num_negatives_per_epoch
+        negative_indices: List[int] = []
+        if len(negative_indices_all) >= num_negatives:
+            indices = torch.randperm(len(negative_indices_all), generator=g)[:num_negatives].tolist()
+            negative_indices = [negative_indices_all[i] for i in indices]
+        else:
+            negative_indices = negative_indices_all.copy()
+            extra_needed = num_negatives - len(negative_indices)
+            if extra_needed > 0:
+                indices = torch.randint(len(negative_indices_all), size=(extra_needed,), generator=g).tolist()
+                negative_indices += [negative_indices_all[i] for i in indices]
+
+        all_indices = self.positive_indices + negative_indices
+
+        if self.shuffle:
+            indices = torch.randperm(len(all_indices), generator=g).tolist()
+            all_indices = [all_indices[i] for i in indices]
+
+        self.dataset._preload_negative_samples(negative_indices)
+        self.num_samples = len(all_indices)
+
+        print(
+            f"GPU {self.rank}: Number of positives: {len(self.positive_indices)}, Number of negatives: {len(negative_indices)}"
+        )
+
+        return iter(all_indices)
+
+    def __len__(self) -> int:
+        return self.num_samples
+
+    def set_epoch(self, epoch: int) -> None:
+        self.epoch = epoch

--- a/ib_sampling/utils.py
+++ b/ib_sampling/utils.py
@@ -1,0 +1,68 @@
+"""Utility helpers for data handling."""
+
+from __future__ import annotations
+
+import glob
+import os
+from typing import List, Tuple
+
+import numpy as np
+
+
+def train_validate_dicts(data_dir: str, args) -> Tuple[List[str], List[str]]:
+    """Split patient IDs into train and validation folds.
+
+    Parameters
+    ----------
+    data_dir: str
+        Directory containing ``lesion_patches`` and ``background_patches``.
+    args: Namespace
+        Requires ``split`` and ``max_splits`` attributes to control the number of
+        cross-validation folds and which fold is used for validation.
+    """
+    lesion_patch_dir = os.path.join(data_dir, "lesion_patches")
+    background_patch_dir = os.path.join(data_dir, "background_patches")
+
+    lesion_files = glob.glob(os.path.join(lesion_patch_dir, "*.nii*"))
+    background_files = glob.glob(os.path.join(background_patch_dir, "*.nii*"))
+
+    all_files = lesion_files + background_files
+
+    patient_ids = set()
+    for file_path in all_files:
+        filename = os.path.basename(file_path)
+        if "label" in filename:
+            continue
+
+        filename_no_ext = filename.replace(".nii.gz", "").replace(".nii", "")
+        parts = filename_no_ext.split("_")
+
+        if len(parts) < 4:
+            continue
+
+        patient_id = "_".join(parts[:-3])
+        patient_ids.add(patient_id)
+
+    patient_ids = sorted(list(patient_ids))
+    print(f"All patient IDs: {patient_ids}")
+
+    np.random.seed(42)
+    np.random.shuffle(patient_ids)
+
+    num_patients = len(patient_ids)
+    max_splits = getattr(args, "max_splits", 7)
+    num_val_patients = max(1, num_patients // max_splits)
+
+    folds = [patient_ids[i : i + num_val_patients] for i in range(0, num_patients, num_val_patients)]
+    if len(folds) > max_splits:
+        folds[-2].extend(folds[-1])
+        folds.pop()
+
+    val_fold_index = (args.split - 1) % len(folds)
+    val_patient_ids = folds[val_fold_index]
+    train_patient_ids = [p for i, fold in enumerate(folds) if i != val_fold_index for p in fold]
+
+    print(f"Training patient IDs: {train_patient_ids}")
+    print(f"Validation patient IDs: {val_patient_ids}")
+
+    return train_patient_ids, val_patient_ids

--- a/prepare_dataset.py
+++ b/prepare_dataset.py
@@ -1,0 +1,205 @@
+"""Script to convert whole-body volumes into patch datasets.
+
+For each subject folder containing multiple modalities (e.g., ``T1.nii.gz`` and
+``b1000.nii.gz``) and a ground-truth mask ``GT.nii.gz``, this script extracts:
+
+* **Positive patches**: one patch per connected component in the mask. Each
+  patch uses the minimal bounding box around the lesion, padded by 10 voxels and
+  enlarged to at least ``128^3`` (or a user-specified size).
+* **Negative patches**: sliding window patches of ``128^3`` with 50% overlap over
+  the volume, skipping any regions that intersect lesions.
+
+All modalities are normalized using the 1st and 99th percentiles before patch
+extraction. Patches are written to ``lesion_patches`` and ``background_patches``
+subdirectories of the output folder using the naming convention expected by the
+``MedicalPatchDataset`` loader.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import nibabel as nib
+import numpy as np
+from scipy import ndimage as ndi
+
+
+def normalize_volume(img: np.ndarray) -> np.ndarray:
+    """Clip to the 1st and 99th percentiles and scale to [0, 1]."""
+    p1, p99 = np.percentile(img, (1, 99))
+    if p99 <= p1:
+        return np.zeros_like(img, dtype=np.float32)
+    img = np.clip(img, p1, p99)
+    return (img - p1) / (p99 - p1)
+
+
+def ensure_size(start: int, end: int, min_size: int, max_dim: int) -> tuple[int, int]:
+    """Expand ``start``/``end`` so the interval is at least ``min_size`` long."""
+    size = end - start
+    if size >= min_size:
+        return start, end
+    extra = min_size - size
+    start = max(0, start - extra // 2)
+    end = min(max_dim, end + extra - extra // 2)
+    if end - start < min_size:
+        if start == 0:
+            end = min(max_dim, start + min_size)
+        else:
+            start = max(0, end - min_size)
+    return start, end
+
+
+def generate_indices(dim: int, patch: int, stride: int) -> list[int]:
+    """Return start indices covering ``dim`` using ``patch`` size and ``stride``."""
+    if dim <= patch:
+        return [0]
+    starts = list(range(0, dim - patch + 1, stride))
+    if starts[-1] != dim - patch:
+        starts.append(dim - patch)
+    return starts
+
+
+def save_patch(
+    pid: str,
+    patch_type: str,
+    patch_idx: int,
+    modalities: dict[str, np.ndarray],
+    label: np.ndarray,
+    out_dir: Path,
+    affine: np.ndarray,
+) -> None:
+    for mod, data in modalities.items():
+        out_path = out_dir / f"{pid}_{mod}_{patch_type}_{patch_idx:04d}.nii.gz"
+        nib.save(nib.Nifti1Image(data.astype(np.float32), affine), out_path)
+    label_path = out_dir / f"{pid}_label_{patch_type}_{patch_idx:04d}.nii.gz"
+    nib.save(nib.Nifti1Image(label.astype(np.float32), affine), label_path)
+
+
+def process_case(
+    case_dir: Path,
+    output_dir: Path,
+    patch_size: tuple[int, int, int],
+    stride: tuple[int, int, int],
+    modalities_filter: list[str] | None,
+) -> None:
+    pid = case_dir.name
+    lesion_dir = output_dir / "lesion_patches"
+    background_dir = output_dir / "background_patches"
+    lesion_dir.mkdir(parents=True, exist_ok=True)
+    background_dir.mkdir(parents=True, exist_ok=True)
+
+    modality_paths: dict[str, Path] = {}
+    gt_path: Path | None = None
+    for path in case_dir.glob("*.nii*"):
+        name = path.name.lower()
+        if name.startswith("gt"):
+            gt_path = path
+        else:
+            mod = path.name.replace(".nii.gz", "").replace(".nii", "")
+            if modalities_filter is None or mod in modalities_filter:
+                modality_paths[mod] = path
+
+    if gt_path is None or not modality_paths:
+        return
+
+    modalities = {}
+    affine = None
+    for mod, p in modality_paths.items():
+        img = nib.load(p)
+        data = normalize_volume(img.get_fdata(dtype=np.float32))
+        modalities[mod] = data.astype(np.float32)
+        if affine is None:
+            affine = img.affine
+
+    gt_img = nib.load(gt_path)
+    label = gt_img.get_fdata(dtype=np.float32)
+    if affine is None:
+        affine = gt_img.affine
+
+    # Positive patches
+    labeled, num = ndi.label(label > 0)
+    pos_idx = 0
+    for comp in range(1, num + 1):
+        mask = labeled == comp
+        coords = np.where(mask)
+        zmin, ymin, xmin = [int(c.min()) for c in coords]
+        zmax, ymax, xmax = [int(c.max()) for c in coords]
+        pad = 10
+        zmin = max(zmin - pad, 0)
+        ymin = max(ymin - pad, 0)
+        xmin = max(xmin - pad, 0)
+        zmax = min(zmax + pad + 1, label.shape[0])
+        ymax = min(ymax + pad + 1, label.shape[1])
+        xmax = min(xmax + pad + 1, label.shape[2])
+
+        zmin, zmax = ensure_size(zmin, zmax, patch_size[0], label.shape[0])
+        ymin, ymax = ensure_size(ymin, ymax, patch_size[1], label.shape[1])
+        xmin, xmax = ensure_size(xmin, xmax, patch_size[2], label.shape[2])
+
+        slices = (slice(zmin, zmax), slice(ymin, ymax), slice(xmin, xmax))
+        label_patch = label[slices]
+        modality_patches = {m: img[slices] for m, img in modalities.items()}
+        save_patch(pid, "positive", pos_idx, modality_patches, label_patch, lesion_dir, affine)
+        pos_idx += 1
+
+    # Negative patches
+    neg_idx = 0
+    z_starts = generate_indices(label.shape[0], patch_size[0], stride[0])
+    y_starts = generate_indices(label.shape[1], patch_size[1], stride[1])
+    x_starts = generate_indices(label.shape[2], patch_size[2], stride[2])
+    for z in z_starts:
+        for y in y_starts:
+            for x in x_starts:
+                z_end, y_end, x_end = z + patch_size[0], y + patch_size[1], x + patch_size[2]
+                slices = (slice(z, z_end), slice(y, y_end), slice(x, x_end))
+                label_patch = label[slices]
+                if np.any(label_patch > 0):
+                    continue
+                modality_patches = {m: img[slices] for m, img in modalities.items()}
+                save_patch(pid, "negative", neg_idx, modality_patches, label_patch, background_dir, affine)
+                neg_idx += 1
+
+    print(f"{pid}: {pos_idx} positive patches, {neg_idx} negative patches")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Prepare dataset into patches")
+    parser.add_argument("input_dir", help="Directory with raw subject folders")
+    parser.add_argument("output_dir", help="Directory to store extracted patches")
+    parser.add_argument("--patch-size", type=int, nargs=3, default=(128, 128, 128))
+    parser.add_argument(
+        "--stride",
+        type=int,
+        nargs=3,
+        default=None,
+        help="Stride for negative patch extraction (defaults to half patch size)",
+    )
+    parser.add_argument(
+        "--modalities",
+        type=str,
+        nargs="+",
+        default=None,
+        help="Optional list of modalities to process (default: all found)",
+    )
+    args = parser.parse_args()
+
+    patch_size = tuple(args.patch_size)
+    if args.stride is None:
+        stride = tuple(s // 2 for s in patch_size)
+    else:
+        stride = tuple(args.stride)
+
+    input_dir = Path(args.input_dir)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    modalities_filter = args.modalities
+    for case in sorted(input_dir.iterdir()):
+        if case.is_dir():
+            process_case(case, output_dir, patch_size, stride, modalities_filter)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- Drop unused LabelMapper transform and package export
- Add optional modality argument with automatic discovery for `MedicalPatchDataset` and `prepare_dataset.py`
- Parameterize train/validation split generation via new `max_splits` argument
- Document raw data layout, patch extraction workflow, and dataloader usage in README

## Testing
- `python -m compileall ib_sampling prepare_dataset.py`

------
https://chatgpt.com/codex/tasks/task_b_689313e468b0832c9f7376371b7c0f8c