### PR TITLE
Add reference to DEMI 2025 paper and citation placeholder

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,19 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite the following work."
+title: "Instance-Balanced Patch Sampling for Whole-Body Lesion Segmentation"
+authors:
+  - family-names: Wuts
+    given-names: Joris
+    orcid: "https://orcid.org/0000-0003-0770-1742"
+  - family-names: Ceranka
+    given-names: Jakub
+    orcid: "https://orcid.org/0000-0002-0241-7737"
+  - family-names: Vandemeulebroucke
+    given-names: Jef
+    orcid: "https://orcid.org/0000-0001-5714-3254"
+  - family-names: Lecouvet
+    given-names: Frédéric
+    orcid: "https://orcid.org/0000-0003-3568-3254"
+# Placeholder for citation details to be updated after MICCAI 2025
+version: 0.1.0
+date-released: 2025-10-01

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ A modular dataloader for patch-based whole-body lesion detection. The package is
 split into small components so the dataset, sampler and loader can be reused in
 other projects or adapted to different modalities.
 
+This repository accompanies the DEMI 2025 workshop paper:
+
+**Instance‑Balanced Patch Sampling for Whole‑Body Lesion Segmentation**<br>
+Joris Wuts, Jakub Ceranka, Jef Vandemeulebroucke, Frédéric Lecouvet<br>
+_Open-access version and citation details will be added after the MICCAI 2025 conference._
+
+Whole-body scans often contain many tiny lesions that make up less than 0.01% of the image volume.
+Conventional positive–negative patch sampling struggles in this setting, over-representing background and large lesions while missing small targets.
+The instance-balanced strategy samples patches per lesion instance, improving CPU data-loading efficiency, training speed and segmentation accuracy.
+
 ## Package structure
 
 ``ib_sampling`` exposes a few key utilities:
@@ -101,4 +111,11 @@ respectively.
 
 This design keeps GPU utilisation high by avoiding repeated disk reads while
 still supporting large background pools.
+
+## Authors
+
+- Joris Wuts
+- Jakub Ceranka
+- Jef Vandemeulebroucke
+- Frédéric Lecouvet
 


### PR DESCRIPTION
## Summary
- reference the upcoming MICCAI DEMI 2025 paper in the README and add sampling motivation
- include author list and placeholder note for future citation
- add a `CITATION.cff` file so GitHub displays citation information

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68933842ca10832cbd3f8b5d66ac6c06